### PR TITLE
Fx list products

### DIFF
--- a/domain/entities/entity_pagination.go
+++ b/domain/entities/entity_pagination.go
@@ -15,6 +15,21 @@ type PaginatedList[T any] struct {
 	Pages int64 `json:"pages"`
 }
 
+// CursorPaginatedList is a generic struct that defines cursor pagination attributes.
+type CursorPaginatedList[T any] struct {
+	// Items is the list of items returned for the current cursor.
+	Items []T `json:"items"`
+
+	// RequestedItems is the number of items that the client requested for.
+	RequestedItems int64 `json:"requested_items"`
+
+	// HasNext defines whether there are more items after this page.
+	HasNext bool `json:"has_next"`
+
+	// NextCursor is the cursor that should be used to request the next page.
+	NextCursor *int64 `json:"next_cursor,omitempty"`
+}
+
 // GeneralFilter is a generic struct that defines basic fields for pagination, sorting and filtering.
 type GeneralFilter struct {
 	// Limit is the maximum number of items that should be returned on a single page.
@@ -31,4 +46,13 @@ type GeneralFilter struct {
 
 	// Search is the search used to filter items.
 	Search string `json:"search"`
+}
+
+// CursorFilter is a generic struct that defines basic fields for cursor pagination.
+type CursorFilter struct {
+	// Limit is the maximum number of items that should be returned on a single page.
+	Limit int64 `json:"limit"`
+
+	// Cursor is the last seen item identifier.
+	Cursor int64 `json:"cursor"`
 }

--- a/domain/usecases/impl/usecase_product.go
+++ b/domain/usecases/impl/usecase_product.go
@@ -21,8 +21,8 @@ type productUseCases struct {
 }
 
 func (p productUseCases) AddNewProduct(
-		ctx context.Context,
-		product *entities.Product,
+	ctx context.Context,
+	product *entities.Product,
 ) (int64, error) {
 	err := rules.ValidateProduct(product)
 	if err != nil {
@@ -37,8 +37,8 @@ func (p productUseCases) DeleteProduct(ctx context.Context, id int64) error {
 }
 
 func (p productUseCases) UpdateProduct(
-		ctx context.Context,
-		product *entities.Product,
+	ctx context.Context,
+	product *entities.Product,
 ) error {
 	err := rules.ValidateProduct(product)
 	if err != nil {
@@ -49,19 +49,31 @@ func (p productUseCases) UpdateProduct(
 }
 
 func (p productUseCases) GetProductByID(
-		ctx context.Context,
-		id int64,
+	ctx context.Context,
+	id int64,
 ) (*entities.Product, error) {
 	return p.repository.GetProductByID(ctx, id)
 }
 
 func (p productUseCases) GetProducts(
-		ctx context.Context,
-		filter entities.GeneralFilter,
+	ctx context.Context,
+	filter entities.GeneralFilter,
 ) (*entities.PaginatedList[entities.Product], error) {
 	products, err := p.repository.GetProducts(ctx, filter)
 	if err != nil {
 		return nil, derr.JoinError("failed to get products", err)
+	}
+
+	return products, nil
+}
+
+func (p productUseCases) GetProductsByCursor(
+	ctx context.Context,
+	filter entities.CursorFilter,
+) (*entities.CursorPaginatedList[entities.Product], error) {
+	products, err := p.repository.GetProductsByCursor(ctx, filter)
+	if err != nil {
+		return nil, derr.JoinError("failed to get products by cursor", err)
 	}
 
 	return products, nil

--- a/domain/usecases/product.go
+++ b/domain/usecases/product.go
@@ -22,7 +22,13 @@ type ProductUseCase interface {
 
 	// GetProducts returns a paginated list of products that match the given filter.
 	GetProducts(
-			ctx context.Context,
-			filter entities.GeneralFilter,
+		ctx context.Context,
+		filter entities.GeneralFilter,
 	) (*entities.PaginatedList[entities.Product], error)
+
+	// GetProductsByCursor returns a cursor paginated list of products.
+	GetProductsByCursor(
+		ctx context.Context,
+		filter entities.CursorFilter,
+	) (*entities.CursorPaginatedList[entities.Product], error)
 }

--- a/infrastructure/datastore/repositories/impl/_query/product/get_products.sql
+++ b/infrastructure/datastore/repositories/impl/_query/product/get_products.sql
@@ -1,9 +1,0 @@
-SELECT
-    id,
-    name,
-    description,
-    price,
-    stock,
-    image_url
-FROM products
-WHERE status_code = 0

--- a/infrastructure/datastore/repositories/impl/mysql_product.go
+++ b/infrastructure/datastore/repositories/impl/mysql_product.go
@@ -161,9 +161,6 @@ WHERE status_code = 0
 
 		products = append(products, product)
 	}
-	if err = rows.Err(); err != nil {
-		return nil, derr.JoinError("failed to iterate rows", err)
-	}
 
 	var totalCount int64
 	err = r.conn.QueryRowContext(ctx, countQuery).Scan(&totalCount)
@@ -218,9 +215,6 @@ WHERE status_code = 0
 		}
 
 		products = append(products, product)
-	}
-	if err = rows.Err(); err != nil {
-		return nil, derr.JoinError("failed to iterate rows", err)
 	}
 
 	hasNext := int64(len(products)) > filter.Limit

--- a/infrastructure/datastore/repositories/impl/mysql_product.go
+++ b/infrastructure/datastore/repositories/impl/mysql_product.go
@@ -35,9 +35,6 @@ var updateProduct string
 //go:embed _query/product/get_product_by_id.sql
 var getProductById string
 
-//go:embed _query/product/get_products.sql
-var getProducts string
-
 func (r productRepository) AddNewProduct(ctx context.Context, product *entities.Product) (int64, error) {
 	res, err := r.conn.ExecContext(
 		ctx,
@@ -117,7 +114,17 @@ func (r productRepository) GetProducts(
 	ctx context.Context,
 	filter entities.GeneralFilter,
 ) (*entities.PaginatedList[entities.Product], error) {
-	query := getProducts
+	query := `
+	SELECT
+    id,
+    name,
+    description,
+    price,
+    stock,
+    image_url
+FROM products
+WHERE status_code = 0
+`
 	ordination := filter.Ordination
 	switch filter.OrderBy {
 	case "name":
@@ -178,7 +185,17 @@ func (r productRepository) GetProductsByCursor(
 	ctx context.Context,
 	filter entities.CursorFilter,
 ) (*entities.CursorPaginatedList[entities.Product], error) {
-	query := getProducts + " AND id > ? ORDER BY id ASC LIMIT ?"
+	query := `
+	SELECT
+    id,
+    name,
+    description,
+    price,
+    stock,
+    image_url
+FROM products
+WHERE status_code = 0
+` + " AND id > ? ORDER BY id ASC LIMIT ?"
 	rows, err := r.conn.QueryContext(ctx, query, filter.Cursor, filter.Limit+1)
 	if err != nil {
 		return nil, derr.JoinError("failed to execute query", err)

--- a/infrastructure/datastore/repositories/impl/mysql_product.go
+++ b/infrastructure/datastore/repositories/impl/mysql_product.go
@@ -173,3 +173,54 @@ func (r productRepository) GetProducts(
 		Pages:          pages,
 	}, nil
 }
+
+func (r productRepository) GetProductsByCursor(
+	ctx context.Context,
+	filter entities.CursorFilter,
+) (*entities.CursorPaginatedList[entities.Product], error) {
+	query := getProducts + " AND id > ? ORDER BY id ASC LIMIT ?"
+	rows, err := r.conn.QueryContext(ctx, query, filter.Cursor, filter.Limit+1)
+	if err != nil {
+		return nil, derr.JoinError("failed to execute query", err)
+	}
+	defer rows.Close()
+
+	products := make([]entities.Product, 0)
+	for rows.Next() {
+		var product entities.Product
+		err = rows.Scan(
+			&product.ID,
+			&product.Name,
+			&product.Description,
+			&product.Price,
+			&product.Stock,
+			&product.ImageURL,
+		)
+		if err != nil {
+			return nil, derr.JoinError("failed to scan", err)
+		}
+
+		products = append(products, product)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, derr.JoinError("failed to iterate rows", err)
+	}
+
+	hasNext := int64(len(products)) > filter.Limit
+	if hasNext {
+		products = products[:filter.Limit]
+	}
+
+	var nextCursor *int64
+	if hasNext && len(products) > 0 {
+		cursor := products[len(products)-1].ID
+		nextCursor = &cursor
+	}
+
+	return &entities.CursorPaginatedList[entities.Product]{
+		Items:          products,
+		RequestedItems: filter.Limit,
+		HasNext:        hasNext,
+		NextCursor:     nextCursor,
+	}, nil
+}

--- a/infrastructure/datastore/repositories/impl/mysql_product.go
+++ b/infrastructure/datastore/repositories/impl/mysql_product.go
@@ -117,19 +117,21 @@ func (r productRepository) GetProducts(
 	ctx context.Context,
 	filter entities.GeneralFilter,
 ) (*entities.PaginatedList[entities.Product], error) {
+	query := getProducts
 	ordination := filter.Ordination
 	switch filter.OrderBy {
 	case "name":
-		getProducts += " ORDER BY name " + ordination
+		query += " ORDER BY name " + ordination
 	case "price":
-		getProducts += " ORDER BY price " + ordination
+		query += " ORDER BY price " + ordination
 	case "stock":
-		getProducts += " ORDER BY stock " + ordination
+		query += " ORDER BY stock " + ordination
 	}
 
-	getProducts = datastore.GetPaginated(getProducts, filter)
+	countQuery := datastore.GetQueryCount(query)
+	query = datastore.GetPaginated(query, filter)
 
-	rows, err := r.conn.QueryContext(ctx, getProducts)
+	rows, err := r.conn.QueryContext(ctx, query)
 	if err != nil {
 		return nil, derr.JoinError("failed to execute query", err)
 	}
@@ -152,8 +154,9 @@ func (r productRepository) GetProducts(
 
 		products = append(products, product)
 	}
-
-	countQuery := datastore.GetQueryCount(getProducts)
+	if err = rows.Err(); err != nil {
+		return nil, derr.JoinError("failed to iterate rows", err)
+	}
 
 	var totalCount int64
 	err = r.conn.QueryRowContext(ctx, countQuery).Scan(&totalCount)

--- a/infrastructure/datastore/repositories/product.go
+++ b/infrastructure/datastore/repositories/product.go
@@ -22,7 +22,13 @@ type ProductRepository interface {
 
 	// GetProducts returns a paginated list of products that match the given filter.
 	GetProducts(
-			ctx context.Context,
-			filter entities.GeneralFilter,
+		ctx context.Context,
+		filter entities.GeneralFilter,
 	) (*entities.PaginatedList[entities.Product], error)
+
+	// GetProductsByCursor returns a cursor paginated list of products.
+	GetProductsByCursor(
+		ctx context.Context,
+		filter entities.CursorFilter,
+	) (*entities.CursorPaginatedList[entities.Product], error)
 }

--- a/infrastructure/router/modules/product_module.go
+++ b/infrastructure/router/modules/product_module.go
@@ -39,7 +39,14 @@ func (m productModule) Routes() []router.RouteDefinition {
 			Description: "List products",
 			Handler:     m.listProducts,
 			HttpMethods: []string{http.MethodGet},
-			Public: true,
+			Public:      true,
+		},
+		{
+			Path:        "/cursor",
+			Description: "List products by cursor",
+			Handler:     m.listProductsByCursor,
+			HttpMethods: []string{http.MethodGet},
+			Public:      true,
 		},
 	}
 }
@@ -61,6 +68,29 @@ func (m productModule) listProducts(w http.ResponseWriter, r *http.Request) {
 	products, err := m.productUseCases.GetProducts(ctx, *filter)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to get products", logger.Err(err))
+		router.HandleError(w, err)
+		return
+	}
+
+	err = router.Write(w, products)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to write response", logger.Err(err))
+	}
+}
+
+func (m productModule) listProductsByCursor(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	filter, err := router.GetCursorFilterFromParams(r)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get cursor filter params", logger.Err(err))
+		router.HandleError(w, err)
+		return
+	}
+
+	products, err := m.productUseCases.GetProductsByCursor(ctx, *filter)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to get products by cursor", logger.Err(err))
 		router.HandleError(w, err)
 		return
 	}

--- a/infrastructure/router/util.go
+++ b/infrastructure/router/util.go
@@ -93,3 +93,39 @@ func GetDefaultFilterFromParams(r *http.Request) (*entities.GeneralFilter, error
 
 	return &filter, nil
 }
+
+// GetCursorFilterFromParams returns a cursor filter entity from the given HTTP request.
+func GetCursorFilterFromParams(r *http.Request) (*entities.CursorFilter, error) {
+	var filter entities.CursorFilter
+	query := r.URL.Query()
+
+	limitStr := query.Get("limit")
+	if limitStr != "" {
+		limit, err := strconv.ParseInt(limitStr, 0, 64)
+		if err != nil {
+			return nil, derr.NewBadRequestError("failed to get limit parameter")
+		}
+
+		filter.Limit = limit
+	}
+
+	cursorStr := query.Get("cursor")
+	if cursorStr != "" {
+		cursor, err := strconv.ParseInt(cursorStr, 0, 64)
+		if err != nil {
+			return nil, derr.NewBadRequestError("failed to get cursor parameter")
+		}
+
+		filter.Cursor = cursor
+	}
+
+	if filter.Limit <= 0 {
+		filter.Limit = defaultLimit
+	}
+
+	if filter.Cursor < 0 {
+		return nil, derr.NewBadRequestError("cursor must be greater than or equal to zero")
+	}
+
+	return &filter, nil
+}


### PR DESCRIPTION
Corrige a listagem de produtos para evitar mutação da query global embutida pelo embed, impedindo acúmulo de ORDER BY/paginação entre requisições. Também ajusta a geração do count para ocorrer antes do LIMIT/OFFSET e adiciona verificação de erro após a iteração das linhas retornadas pelo banco.